### PR TITLE
Bump log4j-core from 2.13.2 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>
 		  <artifactId>log4j-core</artifactId>
-		  <version>[2.13.2,)</version>
+		  <version>[2.17.1,)</version>
 		</dependency>
 		<!-- 
 		<dependency>


### PR DESCRIPTION
*Issue #, if available:*
Noticed that this was bumped on the original FHIRServer repository, but not here.

*Description of changes:*
Following the example of dependabot here:
https://github.com/mithun008/FHIRServer/commit/a688190ef786faa87ee1e2828e63052109b297c1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
